### PR TITLE
sketch of optimizer

### DIFF
--- a/example/ram/compile-tests.lurk
+++ b/example/ram/compile-tests.lurk
@@ -1,0 +1,165 @@
+!(:load "quasi.lurk")
+!(:load "compile.lurk")
+
+!(:assert-eq
+  1
+  (compile-closure
+   1
+   '(b)
+   '()
+   '((a . 1))))
+
+!(:assert-eq
+  1
+  (compile-closure
+   'a
+   '(b)
+   '()
+   '((a . 1))))
+
+!(:assert-eq
+  '(+ 1 b)
+  (compile-closure
+   '(+ a b)
+   '(b)
+   '()
+   '((a . 1))))
+
+!(:assert-eq
+  '(+ 1 b)
+  (compile-closure
+   '(+ a b)
+   '(b)
+   '()
+   '((a . 1) (b . 2))))
+
+!(:assert-eq
+  '(lambda (a) (+ a b))
+  (compile-closure
+   '(lambda (a) (+ a b))
+   '(b)
+   '()
+   '((a . 1))))
+
+!(:assert-eq
+  '(let ((a (+ 1 b))) (+ a b))
+  (compile-closure
+   '(let ((a (+ c b))) (+ a b))
+   '(b)
+   '()
+   '((c . 1))))
+
+!(:assert-eq
+  '(+ 1 b)
+  (compile-closure
+   '(+ a b)
+   '(b)
+   '() ;;(current-ram) TODO: RAM is not an exp
+   '((a . 1))))
+
+!(:assert-eq
+  '(+ 1 b)
+  (let ((a 1))
+    (compile-closure
+     '(+ a b)
+     '(b)
+     '()
+     (current-env))))
+
+!(:assert-eq
+  '(+ (f 1) b)
+  (let ((a 1)
+        ;;(f (lambda (x) x))
+        )
+    (compile-closure
+     '(+ (f a) b)
+     '(b)
+     '()
+     (current-env))))
+
+!(:assert-eq
+  '(+ (f 1) b)
+  (letrec ((a 1)
+           ;;(f (lambda (x) x))
+           )
+    (compile-closure
+     '(+ (f a) b)
+     '(b)
+     '()
+     (current-env))))
+
+!(:assert-eq
+  1
+  ((lambda (x) x) 1))
+
+!(:assert-eq
+  1
+  ((compile (lambda (x) x)) 1))
+
+!(:assert-eq
+  12
+  (let ((a 1)
+        (f (lambda (b) (+ a b))))
+    (* (f 2) (f 3))))
+
+!(:assert-eq
+  12
+  (let ((a 1)
+        (f (lambda (b) (+ a b)))
+        (f (compile f)))
+    (* (f 2) (f 3))))
+
+!(:assert-eq
+  12
+  (letrec ((a 1)
+           (f (lambda (b) (+ a b)))
+           (fc (compile f)))
+    (* (fc 2) (fc 3))))
+
+(define foo 1)
+(define foofun (compile (lambda (x) (+ x foo))))
+!(:assert-eq 3 (foofun 2))
+(define foo 2)
+!(:assert-eq 4 (foofun 3))
+
+!(:assert-eq
+ 1
+ (let ((bar (lambda (y) y)))
+   (let ((f (lambda (z) (bar 1))))
+     (let ((fc (compile f)))
+       (fc '(6 2))))))
+
+!(:assert-eq
+  1
+  (let ((bar (lambda (y z) y)))
+    (let ((f (lambda (x) (bar 1 2))))
+      (let ((fc (compile f)))
+        (fc '(6 3))))))
+
+!(:assert-eq
+  '(6 1)
+  (let ((bar (lambda (y) y)))
+    (let ((f (lambda (x) (bar x))))
+      (let ((fc (compile f)))
+        (fc '(6 1))))))
+
+!(:assert-eq
+  '(6 1)
+  (let ((bar (lambda (x) x)))
+    (let ((f (lambda (x) (bar x))))
+      (let ((fc (compile f)))
+        (fc '(6 1))))))
+
+!(:assert-eq
+  3
+  (let ((+ (lambda (y z) (list y z))))
+    (let ((f (lambda (x) (+ 1 2))))
+      (let ((fc (compile f)))
+        (fc '(6 3))))))
+
+!(:assert-eq
+  6
+  (let ((car (lambda (y) y)))
+    (let ((f (lambda (x) (car x))))
+      (let ((fc (compile f)))
+        (fc '(6 1))))))

--- a/example/ram/compile-tests.lurk
+++ b/example/ram/compile-tests.lurk
@@ -153,6 +153,8 @@
 
 !(:assert-eq
   3
+  ;; this example just respects the semantics of Lurk,
+  ;; in which a built-in like + take precedence over the lexical environment
   (let ((+ (lambda (y z) (list y z))))
     (let ((f (lambda (x) (+ 1 2))))
       (let ((fc (compile f)))
@@ -160,6 +162,7 @@
 
 !(:assert-eq
   6
+  ;; ditto for built-in car
   (let ((car (lambda (y) y)))
     (let ((f (lambda (x) (car x))))
       (let ((fc (compile f)))

--- a/example/ram/compile-tests.lurk
+++ b/example/ram/compile-tests.lurk
@@ -119,6 +119,7 @@
 (define foo 1)
 (define foofun (compile (lambda (x) (+ x foo))))
 !(:assert-eq 3 (foofun 2))
+;; re-defining foo does not change the inlined foo value in foofun
 (define foo 2)
 !(:assert-eq 4 (foofun 3))
 

--- a/example/ram/compile-tests.lurk
+++ b/example/ram/compile-tests.lurk
@@ -163,3 +163,10 @@
     (let ((f (lambda (x) (car x))))
       (let ((fc (compile f)))
         (fc '(6 1))))))
+
+!(:assert-eq
+  '(a b c)
+  (let ((a (lambda (b c) b)))
+    (let ((f (lambda (x) '(a b c))))
+      (let ((fc (compile f)))
+        (fc 1)))))

--- a/example/ram/compile.lurk
+++ b/example/ram/compile.lurk
@@ -1,0 +1,69 @@
+(defmacro or (a b)
+  `(if ,a t ,b))
+
+(define map
+  (lambda (f xs)
+    (if (eq nil xs)
+        nil
+        (cons (f (car xs)) (map f (cdr xs))))))
+
+(define cadr
+  (lambda (xs)
+    (car (cdr xs))))
+
+(define caddr
+  (lambda (xs)
+    (car (cdr (cdr xs)))))
+
+(define cadddr
+  (lambda (xs)
+    (car (cdr (cdr (cdr xs))))))
+
+(define let-bindings cadr)
+(define let-body caddr)
+(define lambda-params cadr)
+(define lambda-body caddr)
+
+(define lookup
+  (lambda (e env success failure)
+    (if (eq nil env)
+        (failure)
+        (if (eq nil (atom (car (car env))))
+            (lookup e (car env) success
+                    (lambda () (lookup e (cdr env) success failure)))
+            (if (eq e (car (car env)))
+                (success (cdr (car env)))
+                (lookup e (cdr env) success failure))))))
+
+(define member
+  (lambda (e xs)
+    (if (eq nil xs)
+        nil
+        (if (eq e (car xs))
+            xs
+            (member e (cdr xs))))))
+
+(define compile-closure
+  (lambda (e params ram env)
+    (let ((init-params (append `(if current-env current-ram eval begin atom car cdr emit quote macroexpand + - / * = eq cons) params))
+          (rec (lambda (e) (compile-closure e init-params ram env)))
+          (rec-params (lambda (e params) (compile-closure e (append init-params params) ram env))))
+      (if (atom e)
+          (if (member e params)
+              e
+              (lookup e env (lambda (v)
+                              ;;(if (procedure v) e v)
+                              v
+                              )
+                      (lambda () (lookup e ram (lambda (v) v) (lambda () e)))))
+          (let ((tag (car e)))
+            (if (or (eq 'let tag) (eq 'letrec tag))
+                ;; NOTE: this over approximates params in the right-hand sides
+                (let ((all-params (append (map (lambda (b) (car b)) (let-bindings e)) params)))
+                  `(,tag
+                    ,(map (lambda (b) `(,(car b) ,(rec-params (cadr b) all-params))) (let-bindings e))
+                    ,(rec-params (let-body e) all-params)))
+                (if (eq 'lambda tag)
+                    `(,tag ,(lambda-params e) ,(rec-params (lambda-body e) (append (lambda-params e) params)))
+                    ;; NOTE: this is post-expansion, so no macros!
+                    (map rec e))))))))

--- a/example/ram/compile.lurk
+++ b/example/ram/compile.lurk
@@ -52,7 +52,7 @@
           (if (member e params)
               e
               (lookup e env (lambda (v)
-                              ;;(if (procedure v) e v)
+                              ;;(if (functionp v) e v)
                               v
                               )
                       (lambda () (lookup e ram (lambda (v) v) (lambda () e)))))

--- a/example/ram/compile.lurk
+++ b/example/ram/compile.lurk
@@ -65,5 +65,7 @@
                     ,(rec-params (let-body e) all-params)))
                 (if (eq 'lambda tag)
                     `(,tag ,(lambda-params e) ,(rec-params (lambda-body e) (append (lambda-params e) params)))
-                    ;; NOTE: this is post-expansion, so no macros!
-                    (map rec e))))))))
+                    (if (eq 'quote tag)
+                        e
+                        ;; NOTE: this is post-expansion, so no macros!
+                        (map rec e)))))))))

--- a/example/tests/spec.lurk
+++ b/example/tests/spec.lurk
@@ -465,10 +465,10 @@
 !(:assert-eq "sdf" (cdr "asdf"))
 
 ;; Construct a string from a character and another string.
-!(:assert-eq "dog" (cons #\d "og"))
+!(:assert-eq "dog" (strcons #\d "og"))
 
 ;; Including the empty string.
-!(:assert-eq "z" (cons #\z ""))
+!(:assert-eq "z" (strcons #\z ""))
 
 ;; The empty string is the string terminator ("")
 !(:assert-eq "" (cdr "x"))


### PR DESCRIPTION
review for discussion

we cannot use (current-ram) and (current-env) for the ram and env, because we need to expose a predicate for closures. here we only use atom otherwise list.