### PR TITLE
Add test of begin's env-handling.

### DIFF
--- a/example/tests/spec.lurk
+++ b/example/tests/spec.lurk
@@ -442,3 +442,26 @@
 ;; env-let-letrec-let
 !(:assert-eq '((e . 5) ((d . 4) (c . 3)) (b . 2) (a . 1))
              (let ((a 1) (b 2)) (letrec ((c 3) (d 4)) (let ((e 5)) (current-env)))))
+
+
+;; TODO: Add assertion to check emitted values.
+!(:assert-eq 3 (begin (emit 1) (emit 2) (emit 3)))
+
+;; TODO: Add assertion to check emitted values.
+!(:assert-eq 1 (begin1 (emit 1) (emit 2) (emit 3)))
+
+!(:assert-eq nil (begin))
+!(:assert-eq nil (begin1))
+
+!(:assert-eq '((a . 1)) (let ((a 1))
+                          (begin
+                           (let ((b 2))
+                             (emit b))
+                           (current-env))))
+
+
+!(:assert-eq '((a . 1)) (let ((a 1))
+                          (begin1
+                           (current-env)
+                           (let ((b 2))
+                             (emit b)))))


### PR DESCRIPTION
I discovered that the current `api.lisp` implementation of BEGIN doesn't handle nested environments correctly. This test exercises the problem.

When I run this new test in the `lurk` REPL, I get the following:
```
API> (let ((a 1))
      (begin
       (let ((b 2))
         ;; TODO: tests to check emitted values.
         (emit b))
       (current-env)))
2
((B . 2) (A . 1))
```

B should be unbound when`(current-env)` is called, but clearly it is still in the env.